### PR TITLE
Fix hash mismatch with yawsso version 0.7.2

### DIFF
--- a/Formula/yawsso.rb
+++ b/Formula/yawsso.rb
@@ -4,7 +4,7 @@ class Yawsso < Formula
   desc "Yet Another AWS SSO - sync up AWS CLI v2 SSO login session to legacy CLI v1 credentials"
   homepage "https://github.com/victorskl/yawsso"
   url "https://github.com/victorskl/yawsso/archive/refs/tags/0.7.2.tar.gz"
-  sha256 "a2f665d12f1d29095a3a103d61638308ea4e2184bce5810ad80eeebddffcfb51"
+  sha256 "bb3cc0fc3732e586d8ee735d0d8feb6e5eb26864697e84db77c69e3fa0906f56"
 
   depends_on "python"
 


### PR DESCRIPTION
Fix for hash mismatch described in issue #2 