### PR TITLE
Update to 1.2.1

### DIFF
--- a/Formula/yawsso.rb
+++ b/Formula/yawsso.rb
@@ -3,8 +3,8 @@ class Yawsso < Formula
 
   desc "Yet Another AWS SSO - sync up AWS CLI v2 SSO login session to legacy CLI v1 credentials"
   homepage "https://github.com/victorskl/yawsso"
-  url "https://github.com/victorskl/yawsso/archive/refs/tags/1.2.0.tar.gz"
-  sha256 "ad4af6cbd15ba87303a4535de9c6cee71f3df3fd4ea38562d24b0d98e94f6a1e"
+  url "https://github.com/victorskl/yawsso/archive/refs/tags/1.2.1.tar.gz"
+  sha256 "019b1a4eef38a245ff8be72a60128afda81247021bbad92c0859a7a718115ad5"
 
   depends_on "python"
 


### PR DESCRIPTION
There was a patch release to fix a minor bug in the auto command which I use.

PR: https://github.com/victorskl/yawsso/pull/98

I've updated the formula to point at the new tar and I've updated the sha256 hash.

Thanks for maintaining this.